### PR TITLE
Make nix-index-unwrapped and comma overridable.

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -1,5 +1,13 @@
-{ packages }:
-{ pkgs, ... }: {
+{ databases }:
+{ pkgs, ... }:
+
+let
+  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = databases.${pkgs.stdenv.system}.database;
+  };
+in
+
+{
   programs.nix-index.enable = true;
-  programs.nix-index.package = packages.${pkgs.stdenv.system}.nix-index-with-db;
+  programs.nix-index.package = nix-index-with-db;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,15 +10,17 @@
       systems = lib.attrNames self.legacyPackages;
       testSystems = [ "x86_64-linux" "aarch64-linux" ];
 
+      databases = import ./packages.nix;
+
       packages = lib.genAttrs systems (system: {
         default = self.packages.${system}.nix-index-with-db;
         nix-index-with-db =
           nixpkgs.legacyPackages.${system}.callPackage ./nix-index-wrapper.nix {
-            nix-index-database = self.legacyPackages.${system}.database;
+            nix-index-database = databases.${system}.database;
           };
         comma-with-db =
           nixpkgs.legacyPackages.${system}.callPackage ./comma-wrapper.nix {
-            nix-index-database = self.legacyPackages.${system}.database;
+            nix-index-database = databases.${system}.database;
           };
       });
     in
@@ -28,15 +30,15 @@
       legacyPackages = import ./packages.nix;
 
       darwinModules.nix-index = import ./darwin-module.nix {
-        inherit (self) packages;
+        inherit databases;
       };
 
       hmModules.nix-index = import ./home-manager-module.nix {
-        inherit (self) packages legacyPackages;
+        inherit databases;
       };
 
       nixosModules.nix-index = import ./nixos-module.nix {
-        inherit packages;
+        inherit databases;
       };
 
       checks = lib.genAttrs testSystems (system:

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -31,7 +31,7 @@ in
   config = {
     programs.nix-index = {
       enable = lib.mkDefault true;
-      package = nix-index-with-db;
+      package = lib.mkDefault nix-index-with-db;
     };
     home.packages = lib.optional config.programs.nix-index-database.comma.enable comma-with-db;
 

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,5 +1,14 @@
-{ packages, legacyPackages }:
+{ databases }:
 { lib, pkgs, config, ... }:
+
+let
+  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = databases.${pkgs.stdenv.system}.database;
+  };
+  comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
+    nix-index-database = databases.${pkgs.stdenv.system}.database;
+  };
+in
 
 {
   options = {
@@ -22,12 +31,12 @@
   config = {
     programs.nix-index = {
       enable = lib.mkDefault true;
-      package = packages.${pkgs.stdenv.system}.nix-index-with-db;
+      package = nix-index-with-db;
     };
-    home.packages = lib.optional config.programs.nix-index-database.comma.enable packages.${pkgs.stdenv.system}.comma-with-db;
+    home.packages = lib.optional config.programs.nix-index-database.comma.enable comma-with-db;
 
     home.file."${config.xdg.cacheHome}/nix-index/files" =
       lib.mkIf config.programs.nix-index.symlinkToCacheHome
-        { source = legacyPackages.${pkgs.stdenv.system}.database; };
+        { source = databases.${pkgs.stdenv.system}.database; };
   };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,5 +1,16 @@
-{ packages }:
-{ config, pkgs, lib, ... }: {
+{ databases }:
+{ config, pkgs, lib, ... }:
+
+let
+  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = databases.${pkgs.stdenv.system}.database;
+  };
+  comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
+    nix-index-database = databases.${pkgs.stdenv.system}.database;
+  };
+in
+
+{
   options = {
     programs.nix-index-database.comma.enable = lib.mkOption {
       type = lib.types.bool;
@@ -10,8 +21,7 @@
 
   config = {
     programs.nix-index.enable = lib.mkDefault true;
-    programs.nix-index.package = lib.mkDefault packages.${pkgs.stdenv.system}.nix-index-with-db;
-    environment.systemPackages = lib.optional config.programs.nix-index-database.comma.enable 
-      packages.${pkgs.stdenv.system}.comma-with-db;
+    programs.nix-index.package = lib.mkDefault nix-index-with-db;
+    environment.systemPackages = lib.optional config.programs.nix-index-database.comma.enable comma-with-db;
   };
 }


### PR DESCRIPTION
Before, we used our own nixpkgs instance instead of the one used for NixOS/home-manager. This is not very efficient (it evals another instance), and does not allow overriding nix-index-unwrapped in an overlay.
