### PR TITLE
Avoid calling builtins.import on modules.

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -1,5 +1,4 @@
-{ databases }:
-{ pkgs, ... }:
+{ pkgs, databases, ... }:
 
 let
   nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -34,16 +34,19 @@
 
       overlays.nix-index = final: prev: mkPackages final;
 
-      darwinModules.nix-index = import ./darwin-module.nix {
-        inherit databases;
+      darwinModules.nix-index = {
+        imports = [ ./darwin-module.nix ];
+        _module.args = { inherit databases; };
       };
 
-      hmModules.nix-index = import ./home-manager-module.nix {
-        inherit databases;
+      hmModules.nix-index = {
+        imports = [ ./home-manager-module.nix ];
+        _module.args = { inherit databases; };
       };
 
-      nixosModules.nix-index = import ./nixos-module.nix {
-        inherit databases;
+      nixosModules.nix-index = {
+        imports = [ ./nixos-module.nix ];
+        _module.args = { inherit databases; };
       };
 
       checks = lib.genAttrs testSystems (system:

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,5 +1,4 @@
-{ databases }:
-{ lib, pkgs, config, ... }:
+{ lib, pkgs, config, databases, ... }:
 
 let
   nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,5 +1,4 @@
-{ databases }:
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, databases, ... }:
 
 let
   nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {


### PR DESCRIPTION
This avoids problems with modules being imported multiple times.
Importing a module that was called with builtins.import results in an anonymous module for which nix has no file information, and so nix cannot detect that the same module was imported multiple times, which can lead to weird errors.

See #81.
Fixes #77.
