### PR TITLE
modules: don't set _module.args

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -1,14 +1,10 @@
-{ lib,  pkgs, databases, ... }:
-
-let
-  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
-    nix-index-database = databases.${pkgs.stdenv.system}.database;
-  };
-in
-
+self:
+{ pkgs, lib, ... }:
 {
   programs.nix-index = {
     enable = lib.mkDefault true;
-    package = lib.mkDefault nix-index-with-db;
+    package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
   };
+
+  _file = ./darwin-module.nix;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,20 +34,11 @@
 
       overlays.nix-index = final: prev: mkPackages final;
 
-      darwinModules.nix-index = {
-        imports = [ ./darwin-module.nix ];
-        _module.args = { inherit databases; };
-      };
+      darwinModules.nix-index = import ./darwin-module.nix self;
 
-      hmModules.nix-index = {
-        imports = [ ./home-manager-module.nix ];
-        _module.args = { inherit databases; };
-      };
+      hmModules.nix-index = import ./home-manager-module.nix self;
 
-      nixosModules.nix-index = {
-        imports = [ ./nixos-module.nix ];
-        _module.args = { inherit databases; };
-      };
+      nixosModules.nix-index = import ./nixos-module.nix self;
 
       checks = lib.genAttrs testSystems (system:
         import ./tests.nix {

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,14 +1,5 @@
-{ lib, pkgs, config, databases, ... }:
-
-let
-  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
-    nix-index-database = databases.${pkgs.stdenv.system}.database;
-  };
-  comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
-    nix-index-database = databases.${pkgs.stdenv.system}.database;
-  };
-in
-
+self:
+{ lib, pkgs, config, ... }:
 {
   options = {
     programs.nix-index.symlinkToCacheHome = lib.mkOption {
@@ -25,15 +16,16 @@ in
   config = {
     programs.nix-index = {
       enable = lib.mkDefault true;
-      package = lib.mkDefault nix-index-with-db;
+      package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
     };
 
     home = {
-      packages = lib.optional config.programs.nix-index-database.comma.enable comma-with-db;
+      packages = lib.optional config.programs.nix-index-database.comma.enable self.packages.${pkgs.stdenv.system}.comma-with-db;
 
       file."${config.xdg.cacheHome}/nix-index/files" =
         lib.mkIf config.programs.nix-index.symlinkToCacheHome
-          { source = databases.${pkgs.stdenv.system}.database; };
+          { source = self.packages.${pkgs.stdenv.system}.nix-index-database; };
     };
   };
+  _file = ./darwin-module.nix;
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,26 +1,17 @@
-{ config, pkgs, lib, databases, ... }:
-
-let
-  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix {
-    nix-index-database = databases.${pkgs.stdenv.system}.database;
-  };
-  comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
-    nix-index-database = databases.${pkgs.stdenv.system}.database;
-  };
-in
-
+self:
+{ config, pkgs, lib, ... }:
 {
   options = {
     programs.nix-index-database.comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
   };
 
-
   config = {
     programs.nix-index = {
       enable = lib.mkDefault true;
-      package = lib.mkDefault nix-index-with-db;
+      package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
     };
-
-    environment.systemPackages = lib.optional config.programs.nix-index-database.comma.enable comma-with-db;
+    environment.systemPackages = lib.optional config.programs.nix-index-database.comma.enable self.packages.${pkgs.stdenv.system}.comma-with-db;
   };
+
+  _file = ./nixos-module.nix;
 }


### PR DESCRIPTION
use import with self instead of using _module.args which will be passed to every module

get comma-with-db and nix-index-with-db from self instead of callPackage

set _file in each module file to fix positional error messages from using import in imports

cherry-picked from https://github.com/nix-community/nix-index-database/pull/103