### PR TITLE
Pass final into the mkPackages function instead of prev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         ) systemPackages
       ) self.packages;
 
-      overlays.nix-index = _: mkPackages;
+      overlays.nix-index = final: _prev: mkPackages final;
 
       darwinModules.nix-index = import ./darwin-module.nix self;
 


### PR DESCRIPTION
This restores the old behaviour from before 2a2e1acc4a1d698c72fb77c69798c4894174a935 and makes the overlay less dependent on the order in which it is applied relative to other overlays.

@Gerg-L 
