### PR TITLE
nix-index-wrapper.nix: command-not-found.sh needs patched nix-locate

### DIFF
--- a/nix-index-wrapper.nix
+++ b/nix-index-wrapper.nix
@@ -15,6 +15,13 @@ symlinkJoin {
 
     wrapProgram $out/bin/nix-locate \
       --set NIX_INDEX_DATABASE $out/share/cache/nix-index
+
+    mkdir -p $out/etc/profile.d
+    rm -f "$out/etc/profile.d/command-not-found.sh"
+    substitute \
+     "${nix-index-unwrapped}/etc/profile.d/command-not-found.sh" \
+     "$out/etc/profile.d/command-not-found.sh" \
+     --replace-fail "${nix-index-unwrapped}" "$out"
   '';
 
   meta.mainProgram = "nix-locate";


### PR DESCRIPTION
command-not-found.sh needs to use the just patched nix-locate rather than the one in nix-index.

I brought this up in #110.  I don't think I explained myself well.  The link to the command-no-found.sh in nix-index has a /nix/store reference to its own nix-locate program.  It needs to be patched to reference the one being patched.