### PR TITLE
nixos-module: disable programs.command-not-found by default

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -15,6 +15,7 @@ self:
       enable = lib.mkDefault true;
       package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
     };
+    programs.command-not-found.enable = lib.mkDefault false;
     environment.systemPackages =
       lib.optional config.programs.nix-index-database.comma.enable
         self.packages.${pkgs.stdenv.system}.comma-with-db;


### PR DESCRIPTION
Our module enables the `nix-index` module in nixpkgs by default. That module asserts that `programs.command-not-found.enabled` must be false. So it would make sense for our module to also disable `programs.command-not-found` by default, since the base default value for it is true (as defined in the `command-not-found` module's code itself).