### PR TITLE
darwin-module: stop setting unused comma.package option

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -8,7 +8,6 @@ self:
 {
   imports = [ ./nix/shared.nix ];
 
-  programs.nix-index-database.comma.package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
   programs.nix-index.package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
   environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable
     [ self.packages.${pkgs.stdenv.system}.comma-with-db ];


### PR DESCRIPTION
Otherwise evaluation fails:

```
error: The option `programs.nix-index-database.comma.package' does not exist. Definition values:
- In `/nix/store/ajkx81c4pl0dyqzja38mgj41mp0r44il-source/darwin-module.nix':
    {
      _type = "override";
      content = <derivation nix-index-with-db-0.1.8>;
      priority = 1000;
    }
```