### PR TITLE
treewide: disable programs.nix-index.enable option by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,15 @@ Include the nixos module in your configuration:
         modules = [
           ./configuration.nix
           nix-index-database.nixosModules.nix-index
-          # optional to also wrap and install comma
-          # { programs.nix-index-database.comma.enable = true; }
+
+          {
+            programs = {
+              # Optionally wrap and install pkgs.comma.
+              nix-index-database.comma.enable = true;
+
+              nix-index.enable = true;
+            };
+          }
         ];
       };
     };
@@ -73,8 +80,15 @@ You can then call `nix-locate` as usual, it will automatically use the database 
         modules = [
           ./configuration.nix
           nix-index-database.darwinModules.nix-index
-          # optional to also wrap and install comma
-          # { programs.nix-index-database.comma.enable = true; }
+
+          {
+            programs = {
+              # Optionally wrap and install pkgs.comma.
+              nix-index-database.comma.enable = true;
+
+              nix-index.enable = true;
+            };
+          }
         ];
       };
     };
@@ -114,8 +128,15 @@ You can then call `nix-locate` as usual, it will automatically use the database 
 
         modules = [
           nix-index-database.hmModules.nix-index
-          # optional to also wrap and install comma
-          # { programs.nix-index-database.comma.enable = true; }
+
+          {
+            programs = {
+              # Optionally wrap and install pkgs.comma.
+              nix-index-database.comma.enable = true;
+
+              nix-index.enable = true;
+            };
+          }
         ];
       };
     };

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -2,6 +2,4 @@
   options = {
     programs.nix-index-database.comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
   };
-
-  config.programs.nix-index.enable = lib.mkDefault true;
 }

--- a/tests.nix
+++ b/tests.nix
@@ -17,7 +17,11 @@
                 {
                   programs.command-not-found.enable = false;
 
-                  programs.nix-index-database.comma.enable = true;
+                  programs = {
+                    nix-index-database.comma.enable = true;
+                    nix-index.enable = true;
+                  };
+
                   # Point comma at our nixpkgs instance.
                   # Passing --nixpkgs-flake instead seems to fail when nix tries to use the network.
                   nix.nixPath = [ "nixpkgs=${nixpkgs}" ];


### PR DESCRIPTION
This patchset does some cleanup and disables the `programs.nix-index.enable` option by default for the following reason:

> ```
> treewide: disable programs.nix-index.enable option by default
>
> Disable the programs.nix-index.enable option by default to align with
> Nix conventions and streamline configuration sharing.
>
> This avoids needing to remember to disable this module across all
> configurations and avoids highly discouraged conditional imports that
> often lead to infinite recursions [1].
>
> [...]
>
> [1]: https://discourse.nixos.org/t/conditional-module-imports/34863/2
> ```

---

The `programs.nix-index.enable` option was first introduced in commit 75e347f5b4ac ("Allow command-not-found integration with home-manager.") and set to `true`:

https://github.com/nix-community/nix-index-database/blob/75e347f5b4ac8029dafdcdb38b589d42f5ba1553/home-manager-module.nix#L6

To this day, `programs.nix-index.enable` is still set to `true`:

https://github.com/nix-community/nix-index-database/blob/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8/nix/shared.nix#L6

---

```
NAHO (5):
  tests: remove default option declaration
  readme: remove trailing whitespaces
  treewide: disable programs.nix-index.enable option by default
  readme: improve programs.nix-index-database.comma.enable description
  readme: subjectively improve examples

 README.md      | 88 ++++++++++++++++++++++++++++++++------------------
 nix/shared.nix |  2 --
 tests.nix      |  6 ++--
 3 files changed, 60 insertions(+), 36 deletions(-)
```