### PR TITLE
Omit symlinks to avoid a file collision

### DIFF
--- a/comma-wrapper.nix
+++ b/comma-wrapper.nix
@@ -1,5 +1,5 @@
 {
-  lib,
+  linkFarm,
   symlinkJoin,
   makeBinaryWrapper,
   comma,
@@ -13,13 +13,11 @@ symlinkJoin {
   name = "comma-with-db-${comma.version}";
   paths = [ commaOverridden ];
   nativeBuildInputs = [ makeBinaryWrapper ];
+  databaseDirectory = linkFarm "nix-index-database" { files = nix-index-database; };
   postBuild = ''
-    mkdir -p $out/share/cache/nix-index
-    ln -s ${nix-index-database} $out/share/cache/nix-index/files
-
     for cmd in "," "comma"; do
       wrapProgram "$out/bin/$cmd" \
-        --set NIX_INDEX_DATABASE $out/share/cache/nix-index
+        --set NIX_INDEX_DATABASE $databaseDirectory
     done
   '';
 

--- a/nix-index-wrapper.nix
+++ b/nix-index-wrapper.nix
@@ -1,4 +1,5 @@
 {
+  linkFarm,
   symlinkJoin,
   makeBinaryWrapper,
   nix-index-unwrapped,
@@ -9,12 +10,10 @@ symlinkJoin {
   name = "nix-index-with-${db-type}-db-${nix-index-unwrapped.version}";
   paths = [ nix-index-unwrapped ];
   nativeBuildInputs = [ makeBinaryWrapper ];
+  databaseDirectory = linkFarm "nix-index-database" { files = nix-index-database; };
   postBuild = ''
-    mkdir -p $out/share/cache/nix-index
-    ln -s ${nix-index-database} $out/share/cache/nix-index/files
-
     wrapProgram $out/bin/nix-locate \
-      --set NIX_INDEX_DATABASE $out/share/cache/nix-index
+      --set NIX_INDEX_DATABASE $databaseDirectory
 
     mkdir -p $out/etc/profile.d
     rm -f "$out/etc/profile.d/command-not-found.sh"


### PR DESCRIPTION
Fixes #134.

This might cause other issues if I missed anything other than nix-locate and comma relying on the previously-provided symlink. I tested nix-locate and comma, they seem to work.