### PR TITLE
Add default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,36 @@
+{ pkgs }:
+let
+  generated = import ./generated.nix;
+
+  nix-index-database =
+    (pkgs.fetchurl {
+      url = generated.url + pkgs.stdenv.system;
+      hash = generated.hashes.${pkgs.stdenv.system};
+    }).overrideAttrs
+      {
+        __structuredAttrs = true;
+        unsafeDiscardReferences.out = true;
+      };
+
+  nix-index-small-database =
+    (pkgs.fetchurl {
+      url = generated.url + pkgs.stdenv.system + "-small";
+      hash = generated.hashes."${pkgs.stdenv.system}-small";
+    }).overrideAttrs
+      {
+        __structuredAttrs = true;
+        unsafeDiscardReferences.out = true;
+      };
+in
+{
+  inherit nix-index-database nix-index-small-database;
+
+  nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix { inherit nix-index-database; };
+  nix-index-with-small-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = nix-index-small-database;
+    db-type = "small";
+  };
+  comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
+    nix-index-database = nix-index-small-database;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,41 +18,7 @@
         "aarch64-darwin"
       ];
 
-      mkPackages =
-        pkgs:
-        let
-          generated = import ./generated.nix;
-
-          nix-index-database =
-            (pkgs.fetchurl {
-              url = generated.url + pkgs.stdenv.system;
-              hash = generated.hashes.${pkgs.stdenv.system};
-            }).overrideAttrs
-              {
-                __structuredAttrs = true;
-                unsafeDiscardReferences.out = true;
-              };
-
-          nix-index-small-database =
-            (pkgs.fetchurl {
-              url = generated.url + pkgs.stdenv.system + "-small";
-              hash = generated.hashes."${pkgs.stdenv.system}-small";
-            }).overrideAttrs
-              {
-                __structuredAttrs = true;
-                unsafeDiscardReferences.out = true;
-              };
-        in
-        {
-          inherit nix-index-database nix-index-small-database;
-
-          nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix { inherit nix-index-database; };
-          nix-index-with-small-db = pkgs.callPackage ./nix-index-wrapper.nix {
-            nix-index-database = nix-index-small-database;
-            db-type = "small";
-          };
-          comma-with-db = pkgs.callPackage ./comma-wrapper.nix { nix-index-database = nix-index-small-database; };
-        };
+      mkPackages = pkgs: import ./default.nix { inherit pkgs; };
     in
     {
       packages = lib.genAttrs systems (


### PR DESCRIPTION
This makes it possible to consume nix-index-database without Nix Flakes.

This is a better alternative to https://github.com/nix-community/nix-index-database/pull/137