### PR TITLE
tests: remove default option declaration

### DIFF
--- a/tests.nix
+++ b/tests.nix
@@ -15,8 +15,6 @@
               imports = [
                 nixIndexModule
                 {
-                  programs.command-not-found.enable = false;
-
                   programs.nix-index-database.comma.enable = true;
                   # Point comma at our nixpkgs instance.
                   # Passing --nixpkgs-flake instead seems to fail when nix tries to use the network.


### PR DESCRIPTION
Fixes: 5f154bf6c2b1 ("nixos-module: disable programs.command-not-found by default")
