### PR TITLE
Revert "treewide: disable programs.nix-index.enable option by default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,8 @@ Include the nixos module in your configuration:
         modules = [
           ./configuration.nix
           nix-index-database.nixosModules.nix-index
-
-          {
-            programs = {
-              # Optionally wrap and install pkgs.comma.
-              nix-index-database.comma.enable = true;
-
-              nix-index.enable = true;
-            };
-          }
+          # optional to also wrap and install comma
+          # { programs.nix-index-database.comma.enable = true; }
         ];
       };
     };
@@ -80,15 +73,8 @@ You can then call `nix-locate` as usual, it will automatically use the database 
         modules = [
           ./configuration.nix
           nix-index-database.darwinModules.nix-index
-
-          {
-            programs = {
-              # Optionally wrap and install pkgs.comma.
-              nix-index-database.comma.enable = true;
-
-              nix-index.enable = true;
-            };
-          }
+          # optional to also wrap and install comma
+          # { programs.nix-index-database.comma.enable = true; }
         ];
       };
     };
@@ -128,15 +114,8 @@ You can then call `nix-locate` as usual, it will automatically use the database 
 
         modules = [
           nix-index-database.hmModules.nix-index
-
-          {
-            programs = {
-              # Optionally wrap and install pkgs.comma.
-              nix-index-database.comma.enable = true;
-
-              nix-index.enable = true;
-            };
-          }
+          # optional to also wrap and install comma
+          # { programs.nix-index-database.comma.enable = true; }
         ];
       };
     };

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -2,4 +2,6 @@
   options = {
     programs.nix-index-database.comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
   };
+
+  config.programs.nix-index.enable = lib.mkDefault true;
 }

--- a/tests.nix
+++ b/tests.nix
@@ -17,11 +17,7 @@
                 {
                   programs.command-not-found.enable = false;
 
-                  programs = {
-                    nix-index-database.comma.enable = true;
-                    nix-index.enable = true;
-                  };
-
+                  programs.nix-index-database.comma.enable = true;
                   # Point comma at our nixpkgs instance.
                   # Passing --nixpkgs-flake instead seems to fail when nix tries to use the network.
                   nix.nixPath = [ "nixpkgs=${nixpkgs}" ];


### PR DESCRIPTION
Reverts nix-community/nix-index-database#132

@trueNAHO this doesn't generate the error about the missing value for the enable option that I was expecting, it just defaults to false. I don't have time to look into it right now, so I'll just revert and we can re-do this again. Sorry about this.