### PR TITLE
use the official output name for home-manager modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,8 @@
 
       hmModules.nix-index = import ./home-manager-module.nix self;
 
+      homeModules.nix-index = import ./home-manager-module.nix self;
+
       nixosModules.nix-index = import ./nixos-module.nix self;
 
       checks = lib.genAttrs testSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,9 @@
 
       darwinModules.nix-index = import ./darwin-module.nix self;
 
-      hmModules.nix-index = import ./home-manager-module.nix self;
+      hmModules.nix-index = builtins.warn "nix-index-database: flake output `hmModules` has been renamed to `homeModules`" (
+        import ./home-manager-module.nix self
+      );
 
       homeModules.nix-index = import ./home-manager-module.nix self;
 


### PR DESCRIPTION
`homeModules` is the proper name for output attribute of home-manager modules.

https://github.com/nix-community/home-manager/blob/45c2985644b60ab64de2a2d93a4d132ecb87cf66/flake-module.nix#L23C1-L25C87:

> `homeConfigurations` is for specific installations. If you want to expose
> reusable configurations, add them to `homeModules` in the form of modules, so
> that you can reference them in this or another flake's `homeConfigurations`.

`hmModules` is kept for backwards compatibility.