### PR TITLE
Use the module-instantiated nixpkgs for the packages

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -5,12 +5,16 @@ self:
   config,
   ...
 }:
+let
+  packages = pkgs.callPackage self { };
+in
 {
   imports = [ ./nix/shared.nix ];
 
-  programs.nix-index.package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable
-    [ self.packages.${pkgs.stdenv.system}.comma-with-db ];
+  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
+    packages.comma-with-db
+  ];
 
   _file = ./darwin-module.nix;
 }

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -5,21 +5,24 @@ self:
   config,
   ...
 }:
+let
+  packages = pkgs.callPackage self { };
+in
 {
   imports = [
     ./nix/shared.nix
     ./nix/home-manager-options.nix
   ];
-  programs.nix-index.package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
+  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
 
   home = {
     packages = lib.mkIf config.programs.nix-index-database.comma.enable [
-      self.packages.${pkgs.stdenv.system}.comma-with-db
+      packages.comma-with-db
     ];
 
     file."${config.xdg.cacheHome}/nix-index/files" =
       lib.mkIf config.programs.nix-index.symlinkToCacheHome
-        { source = self.packages.${pkgs.stdenv.system}.nix-index-database; };
+        { source = packages.nix-index-database; };
   };
   _file = ./home-manager-module.nix;
 }

--- a/nix-index-wrapper.nix
+++ b/nix-index-wrapper.nix
@@ -4,7 +4,7 @@
   makeBinaryWrapper,
   nix-index-unwrapped,
   nix-index-database,
-  db-type ? "full"
+  db-type ? "full",
 }:
 symlinkJoin {
   name = "nix-index-with-${db-type}-db-${nix-index-unwrapped.version}";

--- a/nix/home-manager-options.nix
+++ b/nix/home-manager-options.nix
@@ -1,4 +1,5 @@
-{ lib, config, ... }: {
+{ lib, config, ... }:
+{
   options = {
     programs.nix-index.symlinkToCacheHome = lib.mkOption {
       type = lib.types.bool;

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -1,4 +1,5 @@
-{ lib, ... }: {
+{ lib, ... }:
+{
   options = {
     programs.nix-index-database.comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
   };

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -5,14 +5,17 @@ self:
   config,
   ...
 }:
+let
+  packages = pkgs.callPackage self { };
+in
 {
   imports = [ ./nix/shared.nix ];
 
-  programs.nix-index.package = lib.mkDefault self.packages.${pkgs.stdenv.system}.nix-index-with-db;
-
+  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
   programs.command-not-found.enable = lib.mkDefault false;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable
-    [ self.packages.${pkgs.stdenv.system}.comma-with-db ];
+  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
+    packages.comma-with-db
+  ];
 
   _file = ./nixos-module.nix;
 }


### PR DESCRIPTION
I added an overlay to try out comma 2.0, but I was confused why 2.0 wasn't realized. After poking around, it turns out that it is because this package uses the flake-input nixpkgs for realization, not the module-instanced nixpkgs. This means applying overlays within your nixos/home-manager/darwin modules don't effect these modules.

This should fix that.