### PR TITLE
fix: home-manager module rename warn and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can then call `nix-locate` as usual, it will automatically use the database 
         inherit pkgs;
 
         modules = [
-          nix-index-database.hmModules.nix-index
+          nix-index-database.homeModules.nix-index
           # optional to also wrap and install comma
           # { programs.nix-index-database.comma.enable = true; }
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
 
       darwinModules.nix-index = import ./darwin-module.nix self;
 
-      hmModules.nix-index = builtins.warn "nix-index-database: flake output `hmModules` has been renamed to `homeModules`" (
+      hmModules.nix-index = lib.warn "nix-index-database: flake output `hmModules` has been renamed to `homeModules`" (
         import ./home-manager-module.nix self
       );
 


### PR DESCRIPTION
fix #152 

┏━ 1 Traces:
┃ trace: evaluation warning: nix-index-database: flake output `hmModules` has been renamed to `homeModules`
┣━ Dependency Graph:
┃          ┌─ ✔ nixvim
┃       ┌─ ✔ home-manager-path ⏱ 2s
┃    ┌─ ✔ activation-script
┃ ┌─ ✔ home-manager-generation
┃ ✔ activatable-home-manager-generation
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 5 │ ⏸ 0 │ ⚠ Finished with 1 traces reported by nix at 04:33:24 after 35s
