### PR TITLE
Bugfix/missing release files

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,7 @@ jobs:
     needs: update-lock
     outputs:
       release_name: ${{ steps.date.outputs.date }}
+      release_id: ${{ steps.create_release.outputs.id }}
     steps:
     - name: Get current date
       id: date
@@ -41,6 +42,7 @@ jobs:
       with:
         name: Release ${{ steps.date.outputs.date }}
         tag_name: ${{ steps.date.outputs.date }}
+        draft: true
 
 
   index:
@@ -167,3 +169,25 @@ jobs:
           git commit -m "update generated.nix to release ${{ needs.create-release.outputs.release_name }}"
           git push origin HEAD:main
         fi
+
+  finalize-release:
+    runs-on: ubuntu-latest
+    needs:
+      - create-release
+      - update-generated
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const release_name = "${{ needs.create-release.outputs.release_name }}";
+            const release_id = "${{ needs.create-release.outputs.release_id }}";
+            core.info(`Finalizing release: ${release_name} (${release_id})`)
+            core.debug(
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id,
+                draft: false,
+              })
+            );


### PR DESCRIPTION
This should at least work around the consequences of the insufficient space issue.

One might consider this a fix for

- #149

once the workflow has run successfully again. But I think

- #153 

should stay open for further debugging using the new `df` output.