### PR TITLE
ci: Fix Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,10 +9,7 @@ queue_rules:
       - check-success=package default [x86_64-linux]
       - check-success=package nix-index-with-db [aarch64-linux]
       - check-success=package nix-index-with-db [x86_64-linux]
-defaults:
-  actions:
-    queue:
-      merge_method: rebase
+    merge_method: rebase
 pull_request_rules:
   - name: merge using the merge queue
     conditions:


### PR DESCRIPTION
The Mergify job complained about
```
Extra inputs are not permitted @ root → defaults → actions → queue → merge_method → rebase
```

Ref: https://changelog.mergify.com/changelog/queue-action-options-deprecation