### PR TITLE
comma: Use overrideAttrs instead of creating a new derivation

### DIFF
--- a/comma-wrapper.nix
+++ b/comma-wrapper.nix
@@ -1,25 +1,26 @@
 {
   linkFarm,
-  symlinkJoin,
   makeBinaryWrapper,
   comma,
   nix-index-unwrapped,
   nix-index-database,
 }:
-let
-  commaOverridden = comma.override { inherit nix-index-unwrapped; };
-in
-symlinkJoin {
-  name = "comma-with-db-${comma.version}";
-  paths = [ commaOverridden ];
-  nativeBuildInputs = [ makeBinaryWrapper ];
-  databaseDirectory = linkFarm "nix-index-database" { files = nix-index-database; };
-  postBuild = ''
-    for cmd in "," "comma"; do
-      wrapProgram "$out/bin/$cmd" \
-        --set NIX_INDEX_DATABASE $databaseDirectory
-    done
-  '';
 
-  meta.mainProgram = "comma";
-}
+(comma.override {
+  inherit nix-index-unwrapped;
+}).overrideAttrs
+  (oldAttrs: {
+    pname = "comma-with-db";
+
+    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [ makeBinaryWrapper ];
+
+    databaseDirectory = linkFarm "nix-index-database" { files = nix-index-database; };
+
+    postInstall =
+      (oldAttrs.postInstall or "")
+      + ''
+        for cmd in "," "comma"; do
+          wrapProgram "$out/bin/$cmd" --set NIX_INDEX_DATABASE $databaseDirectory
+        done
+      '';
+  })


### PR DESCRIPTION
This fixes the issue where the shebang in https://github.com/nix-community/comma/pull/85 points to the unwrapped comma, and should be less fragile overall.