### PR TITLE
Generate index db for nixpkgs stable branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -59,6 +59,12 @@ jobs:
       x86_64-linux-small-hash: ${{ steps.hashes.outputs.x86_64-linux-small }}
       aarch64-linux-small-hash: ${{ steps.hashes.outputs.aarch64-linux-small }}
       aarch64-darwin-small-hash: ${{ steps.hashes.outputs.aarch64-darwin-small }}
+      x86_64-linux-stable-hash: ${{ steps.hashes.outputs.x86_64-linux-stable }}
+      aarch64-linux-stable-hash: ${{ steps.hashes.outputs.aarch64-linux-stable }}
+      aarch64-darwin-stable-hash: ${{ steps.hashes.outputs.aarch64-darwin-stable }}
+      x86_64-linux-stable-small-hash: ${{ steps.hashes.outputs.x86_64-linux-stable-small }}
+      aarch64-linux-stable-small-hash: ${{ steps.hashes.outputs.aarch64-linux-stable-small }}
+      aarch64-darwin-stable-small-hash: ${{ steps.hashes.outputs.aarch64-darwin-stable-small }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -113,11 +119,21 @@ jobs:
       run: |
         nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | tr '\r' '\n' | grep -v '+ generating index:'
         mv ./${{ matrix.system }}-index-small/files ./index-${{ matrix.system }}-small
+    - name: generate stable full nix-index database
+      run: |
+        nix shell --inputs-from .# nixpkgs#nix-index -c nix-index --db ./${{ matrix.system }}-index-stable --system ${{matrix.system}} --nixpkgs 'https://github.com/NixOS/nixpkgs/archive/${{ endsWith(matrix.system, '-darwin') && 'nixpkgs-26.05-darwin' || 'nixos-26.05' }}.tar.gz' 2>&1 | grep -v '+ generating index:'
+        mv ./${{ matrix.system }}-index-stable/files ./index-${{ matrix.system }}-stable
+    - name: generate stable small nix-index database
+      run: |
+        nix shell --inputs-from .# nixpkgs#nix-index -c nix-index --db ./${{ matrix.system }}-index-stable-small --system ${{matrix.system}} --nixpkgs 'https://github.com/NixOS/nixpkgs/archive/${{ endsWith(matrix.system, '-darwin') && 'nixpkgs-26.05-darwin' || 'nixos-26.05' }}.tar.gz' --filter-prefix '/bin/' 2>&1 | grep -v '+ generating index:'
+        mv ./${{ matrix.system }}-index-stable-small/files ./index-${{ matrix.system }}-stable-small
     - name: hash index
       id: hashes
       run: |
         echo "${{ matrix.system }}=$(nix store prefetch-file "file://$PWD/index-${{ matrix.system }}" --json | jq -r .hash)" >> "$GITHUB_OUTPUT"
         echo "${{ matrix.system }}-small=$(nix store prefetch-file "file://$PWD/index-${{ matrix.system }}-small" --json | jq -r .hash)" >> "$GITHUB_OUTPUT"
+        echo "${{ matrix.system }}-stable=$(nix store prefetch-file "file://$PWD/index-${{ matrix.system }}-stable" --json | jq -r .hash)" >> "$GITHUB_OUTPUT"
+        echo "${{ matrix.system }}-stable-small=$(nix store prefetch-file "file://$PWD/index-${{ matrix.system }}-stable-small" --json | jq -r .hash)" >> "$GITHUB_OUTPUT"
     - name: add to release
       uses: softprops/action-gh-release@v3
       with:
@@ -125,6 +141,8 @@ jobs:
         files: |
           index-${{ matrix.system }}-small
           index-${{ matrix.system }}
+          index-${{ matrix.system }}-stable
+          index-${{ matrix.system }}-stable-small
 
 
   update-generated:
@@ -150,6 +168,12 @@ jobs:
             x86_64-linux-small = "${{ needs.index.outputs.x86_64-linux-small-hash }}";
             aarch64-linux-small = "${{ needs.index.outputs.aarch64-linux-small-hash }}";
             aarch64-darwin-small = "${{ needs.index.outputs.aarch64-darwin-small-hash }}";
+            x86_64-linux-stable = "${{ needs.index.outputs.x86_64-linux-stable-hash }}";
+            aarch64-linux-stable = "${{ needs.index.outputs.aarch64-linux-stable-hash }}";
+            aarch64-darwin-stable = "${{ needs.index.outputs.aarch64-darwin-stable-hash }}";
+            x86_64-linux-stable-small = "${{ needs.index.outputs.x86_64-linux-stable-small-hash }}";
+            aarch64-linux-stable-small = "${{ needs.index.outputs.aarch64-linux-stable-small-hash }}";
+            aarch64-darwin-stable-small = "${{ needs.index.outputs.aarch64-darwin-stable-small-hash }}";
           };
         }
         EOF

--- a/default.nix
+++ b/default.nix
@@ -21,13 +21,45 @@ let
         __structuredAttrs = true;
         unsafeDiscardReferences.out = true;
       };
+
+  nix-index-stable-database =
+    (pkgs.fetchurl {
+      url = generated.url + pkgs.stdenv.system + "-stable";
+      hash = generated.hashes."${pkgs.stdenv.system}-stable";
+    }).overrideAttrs
+      {
+        __structuredAttrs = true;
+        unsafeDiscardReferences.out = true;
+      };
+
+  nix-index-stable-small-database =
+    (pkgs.fetchurl {
+      url = generated.url + pkgs.stdenv.system + "-stable-small";
+      hash = generated.hashes."${pkgs.stdenv.system}-stable-small";
+    }).overrideAttrs
+      {
+        __structuredAttrs = true;
+        unsafeDiscardReferences.out = true;
+      };
 in
 {
-  inherit nix-index-database nix-index-small-database;
+  inherit
+    nix-index-database
+    nix-index-small-database
+    nix-index-stable-database
+    nix-index-stable-small-database
+    ;
 
   nix-index-with-db = pkgs.callPackage ./nix-index-wrapper.nix { inherit nix-index-database; };
   nix-index-with-small-db = pkgs.callPackage ./nix-index-wrapper.nix {
     nix-index-database = nix-index-small-database;
+    db-type = "small";
+  };
+  nix-index-with-stable-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = nix-index-stable-database;
+  };
+  nix-index-with-stable-small-db = pkgs.callPackage ./nix-index-wrapper.nix {
+    nix-index-database = nix-index-stable-small-database;
     db-type = "small";
   };
   comma-with-db = pkgs.callPackage ./comma-wrapper.nix {


### PR DESCRIPTION
For now, `nixos-26.05` branch for linux, `nixpkgs-26.05-darwin` branch for darwin.

Tested in fork https://github.com/azuwis/nix-index-database

Release https://github.com/azuwis/nix-index-database/releases/tag/2026-07-21-022646

Action https://github.com/azuwis/nix-index-database/actions/runs/29795823767

Generated commit https://github.com/azuwis/nix-index-database/commit/2ea2301250d1e8053625d9eb01ddf233c54c5d36

See also https://github.com/nix-community/nix-index-database/issues/127#issuecomment-2888221438