### PR TITLE
Add programs.nix-index-database.enable flag, default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You can then call `nix-locate` as usual, it will automatically use the database 
         modules = [
           ./configuration.nix
           nix-index-database.darwinModules.nix-index
+          # optional, this is the default
+          # { programs.nix-index-database.enable = true; }
           # optional to also wrap and install comma
           # { programs.nix-index-database.comma.enable = true; }
         ];

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -8,11 +8,21 @@ let
   packages = import ./. { inherit pkgs; };
 in
 {
-  imports = [ ./nix/shared.nix ];
+  options.programs.nix-index-database = {
+    enable = lib.mkOption {
+      default = true;
+      description = "Whether to enable nix-index-database";
+      type = lib.types.bool;
+    };
+    comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
+  };
 
-  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
-  programs.command-not-found.enable = lib.mkDefault false;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
-    packages.comma-with-db
-  ];
+  config = lib.mkIf config.programs.nix-index-database.enable {
+    programs.nix-index.enable = lib.mkDefault true;
+    programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+    programs.command-not-found.enable = lib.mkDefault false;
+    environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
+      packages.comma-with-db
+    ];
+  };
 }


### PR DESCRIPTION
My understanding of the NixOS module system is that importing a module shouldn't automatically enable it. In my own configs I take advantage of this by having a common set of imports across multiple systems. I can then enable individual modules.

So I can continue using that pattern, I've added an "enabled" flag to the config of this module. I've made it default to enabled, so this isn't a breaking change. Though it would be nice to someday make this disabled by default, having this option improves the situation for people with setups like mine.

Since module imports can't be dynamically enabled based on configs, I duplicated the contents of `nix/shared.nix` into `nixos-module.nix`.

AI disclaimer: I wrote this PR by hand, but I used Claude Code to help me figure out how to run the tests locally.