### PR TITLE
feat: make 'comma' package configurable

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -6,12 +6,13 @@
 }:
 let
   packages = import ./. { inherit pkgs; };
+  cfg = config.programs.nix-index-database;
 in
 {
   imports = [ ./nix/shared.nix ];
 
   programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
-    packages.comma-with-db
+  environment.systemPackages = lib.mkIf cfg.comma.enable [
+    cfg.comma.package
   ];
 }

--- a/default.nix
+++ b/default.nix
@@ -33,4 +33,7 @@ in
   comma-with-db = pkgs.callPackage ./comma-wrapper.nix {
     nix-index-database = nix-index-small-database;
   };
+  comma-with-full-db = pkgs.callPackage ./comma-wrapper.nix {
+    inherit nix-index-database;
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
         import ./tests.nix {
           inherit system nixpkgs;
           nixIndexModule = self.nixosModules.nix-index;
+          nixIndexOverlay = self.overlays.nix-index;
         }
       );
 

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -6,6 +6,7 @@
 }:
 let
   packages = import ./. { inherit pkgs; };
+  cfg = config.programs.nix-index-database;
 in
 {
   imports = [
@@ -15,8 +16,8 @@ in
   programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
 
   home = {
-    packages = lib.mkIf config.programs.nix-index-database.comma.enable [
-      packages.comma-with-db
+    packages = lib.mkIf cfg.comma.enable [
+      cfg.comma.package
     ];
 
     file."${config.xdg.cacheHome}/nix-index/files" =

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -1,7 +1,13 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
+let
+  packages = import ../. { inherit pkgs; };
+in
 {
   options = {
-    programs.nix-index-database.comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
+    programs.nix-index-database.comma = {
+      enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
+      package = lib.mkPackageOption packages "comma-with-db" { };
+    };
   };
 
   config.programs.nix-index.enable = lib.mkDefault true;

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -6,7 +6,12 @@ in
   options = {
     programs.nix-index-database.comma = {
       enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
-      package = lib.mkPackageOption packages "comma-with-db" { };
+      package = lib.mkPackageOption packages "comma-with-db" {
+        default = if config.programs.nix-index.enable then
+            "comma-with-full-db"
+          else
+            "comma-with-db";
+      };
     };
   };
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -6,13 +6,14 @@
 }:
 let
   packages = import ./. { inherit pkgs; };
+  cfg = config.programs.nix-index-database;
 in
 {
   imports = [ ./nix/shared.nix ];
 
   programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
   programs.command-not-found.enable = lib.mkDefault false;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
-    packages.comma-with-db
+  environment.systemPackages = lib.mkIf cfg.comma.enable [
+    cfg.comma.package
   ];
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -6,6 +6,7 @@
 }:
 let
   packages = import ./. { inherit pkgs; };
+  cfg = config.programs.nix-index-database;
 in
 {
   options.programs.nix-index-database = {
@@ -14,15 +15,18 @@ in
       description = "Whether to enable nix-index-database";
       type = lib.types.bool;
     };
-    comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
+    comma = {
+      enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
+      package = lib.mkPackageOption packages "comma-with-db" { };
+    };
   };
 
-  config = lib.mkIf config.programs.nix-index-database.enable {
+  config = lib.mkIf cfg.enable {
     programs.nix-index.enable = lib.mkDefault true;
     programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
     programs.command-not-found.enable = lib.mkDefault false;
-    environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
-      packages.comma-with-db
+    environment.systemPackages = lib.mkIf cfg.comma.enable [
+      cfg.comma.package
     ];
   };
 }

--- a/tests.nix
+++ b/tests.nix
@@ -2,13 +2,14 @@
   system,
   nixpkgs,
   nixIndexModule,
+  nixIndexOverlay,
 }:
 {
   nixosTest = nixpkgs.lib.nixos.runTest {
     name = "nix-index-nixos-test";
     imports = [
       {
-        nodes = {
+        nodes = rec {
           node1 =
             { pkgs, ... }:
             {
@@ -23,6 +24,20 @@
                   virtualisation.additionalPaths = [ pkgs.ripgrep ];
                 }
               ];
+              nixpkgs.overlays = [ nixIndexOverlay ];
+            };
+          node2 =
+            { pkgs, ... }:
+            {
+              imports = [
+                node1
+                {
+                  nixpkgs.overlays = [ nixIndexOverlay ];
+                  programs.nix-index-database.comma.package = pkgs.comma-with-db.override {
+                    inherit (pkgs) nix-index-database;
+                  };
+                }
+              ];
             };
         };
         testScript = ''
@@ -34,10 +49,17 @@
             "cut -d' ' -f1",
             "grep -F 'ripgrep.out'"
           ]))
+          node2.succeed(" | ".join([
+            "nix-locate --whole-name --at-root '/share/man/man1/rg.1'",
+            "cut -d' ' -f1",
+            "grep -F 'ripgrep.out'"
+          ]))
 
           # Check that comma works
           node1.fail("rg --help")
+          node2.fail("rg --help")
           node1.succeed(", rg --help")
+          node2.succeed(", rg --help")
         '';
       }
     ];

--- a/tests.nix
+++ b/tests.nix
@@ -2,13 +2,14 @@
   system,
   nixpkgs,
   nixIndexModule,
+  nixIndexOverlay,
 }:
 {
   nixosTest = nixpkgs.lib.nixos.runTest {
     name = "nix-index-nixos-test";
     imports = [
       {
-        nodes = {
+        nodes = rec {
           node1 =
             { pkgs, ... }:
             {
@@ -25,6 +26,20 @@
                   virtualisation.additionalPaths = [ pkgs.ripgrep ];
                 }
               ];
+              nixpkgs.overlays = [ nixIndexOverlay ];
+            };
+          node2 =
+            { pkgs, ... }:
+            {
+              imports = [
+                node1
+                {
+                  nixpkgs.overlays = [ nixIndexOverlay ];
+                  programs.nix-index-database.comma.package = pkgs.comma-with-db.override {
+                    inherit (pkgs) nix-index-database;
+                  };
+                }
+              ];
             };
         };
         testScript = ''
@@ -36,10 +51,17 @@
             "cut -d' ' -f1",
             "grep -F 'ripgrep.out'"
           ]))
+          node2.succeed(" | ".join([
+            "nix-locate --whole-name --at-root '/share/man/man1/rg.1'",
+            "cut -d' ' -f1",
+            "grep -F 'ripgrep.out'"
+          ]))
 
           # Check that comma works
           node1.fail("rg --help")
+          node2.fail("rg --help")
           node1.succeed(", rg --help")
+          node2.succeed(", rg --help")
         '';
       }
     ];


### PR DESCRIPTION
To, for example, allow having only a single database. This helps to minimize fetches and thus avoid needing them when modifying configs on systems without internet.