### PR TITLE
workflow: build index from updated flake.lock

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -63,6 +63,8 @@ jobs:
       aarch64-darwin-small-hash: ${{ steps.hashes.outputs.aarch64-darwin-small }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: "${{ github.ref_name }}"
     - name: Swap space report before modification
       shell: bash
       run: |


### PR DESCRIPTION
The recent index-generate runs failed with:

```
error: attribute 'nodePackages' in selection path 'nodePackages' not found
```

The `index` job's `actions/checkout` step has no `ref:`, so it checks out the
SHA that triggered the workflow — before the `update-lock` job pushed the new
`flake.lock` to `main`. The database was therefore always built with last
week's pinned nixpkgs, one update behind.

That stale nixpkgs still ships a `nix-index` build that queries `nodePackages`
as an extra scope, which has since been removed from nixpkgs-unstable, so
`nix-env` fails. The lock had already been bumped to a fixed `nix-index`, but
the index job never saw it.

Check out `${{ github.ref_name }}` instead, like `update-generated` already
does, so the index job builds from the freshly-updated `flake.lock`.


Fixes #173.
Fixes #182.
