### PR TITLE
Add adhoc download script to flake apps output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,31 @@
 
       overlays.nix-index = final: _prev: mkPackages final;
 
+      apps = lib.genAttrs systems (system: {
+        default =
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            adhocDownloadScript = pkgs.writeShellApplication {
+              name = "adhoc-download";
+              runtimeInputs = with pkgs; [
+                wget
+                bash
+              ];
+              text = ''
+                #!/usr/bin/env bash
+                filename="index-$(uname -m | sed 's/^arm64$/aarch64/')-$(uname | tr '[:upper:]' '[:lower:]')"
+                mkdir -p ~/.cache/nix-index && cd ~/.cache/nix-index
+                wget -q -N https://github.com/nix-community/nix-index-database/releases/latest/download/"$filename"
+                ln -f "$filename" files
+              '';
+            };
+          in
+          {
+            type = "app";
+            program = "${lib.getExe adhocDownloadScript}";
+          };
+      });
+
       darwinModules = {
         default = self.darwinModules.nix-index;
         nix-index = ./darwin-module.nix;


### PR DESCRIPTION
Flakes support running apps, this change adds the adhoc download script at the bottom of the readme to the flake output, allowing users who don't have this installed to run `nix run github:nix-community/nix-index-database` and automatically have it.

If the location of the writeShellApplication is bad, I can change it since I know some people want a clean flake.