### PR TITLE
ci: run nix-index from upstream repo instead of nixpkgs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -109,11 +109,11 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: generate full nix-index database
       run: |
-        nix shell --inputs-from .# nixpkgs#nix-index -c nix-index --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | grep -v '+ generating full index:'
+        nix run github:nix-community/nix-index -- --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | grep -v '+ generating full index:'
         mv ./${{ matrix.system }}-index/files ./index-${{ matrix.system }}
     - name: generate small nix-index database
       run: |
-        nix shell --inputs-from .# nixpkgs#nix-index -c nix-index --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | grep -v '+ generating small index:'
+        nix run github:nix-community/nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | grep -v '+ generating small index:'
         mv ./${{ matrix.system }}-index-small/files ./index-${{ matrix.system }}-small
     - name: hash index
       id: hashes


### PR DESCRIPTION
nixpkgs' nix-index predates the zstd-compressed .ls listing support
(nix-community/nix-index#320), so indexing against current Hydra output
fails. Pull nix-index straight from the upstream flake to pick up the
zstd handling.
