### PR TITLE
ci: run nix-index app, not default nix-locate

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -109,11 +109,11 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: generate full nix-index database
       run: |
-        nix run github:nix-community/nix-index -- --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | grep -v '+ generating full index:'
+        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | grep -v '+ generating full index:'
         mv ./${{ matrix.system }}-index/files ./index-${{ matrix.system }}
     - name: generate small nix-index database
       run: |
-        nix run github:nix-community/nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | grep -v '+ generating small index:'
+        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | grep -v '+ generating small index:'
         mv ./${{ matrix.system }}-index-small/files ./index-${{ matrix.system }}-small
     - name: hash index
       id: hashes


### PR DESCRIPTION
nix run github:nix-community/nix-index defaults to the nix-locate app,
which rejects --system. Target the nix-index app explicitly.
