### PR TITLE
ci: filter nix-index progress lines from log

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -109,11 +109,11 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: generate full nix-index database
       run: |
-        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | grep -v '+ generating full index:'
+        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index --system ${{matrix.system}} 2>&1 | tr '\r' '\n' | grep -v '+ generating index:'
         mv ./${{ matrix.system }}-index/files ./index-${{ matrix.system }}
     - name: generate small nix-index database
       run: |
-        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | grep -v '+ generating small index:'
+        nix run github:nix-community/nix-index#nix-index -- --db ./${{ matrix.system }}-index-small --system ${{matrix.system}} --filter-prefix '/bin/' 2>&1 | tr '\r' '\n' | grep -v '+ generating index:'
         mv ./${{ matrix.system }}-index-small/files ./index-${{ matrix.system }}-small
     - name: hash index
       id: hashes


### PR DESCRIPTION
The old grep matched '+ generating full index:', a string nix-index
never prints; it emits '+ generating index: N paths found ...'
terminated by carriage return, so line-based grep never dropped it and
the CI log filled with progress spam. Split on CR first, then drop the
progress lines.
