### PR TITLE
feat: make nix-index-with-small-db the default package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ $ nix run github:nix-community/nix-index-database bin/cntr
 cntr.out                                        978,736 x /nix/store/09p2hys5bxcnzcaad3bknlnwsgdkznl1-cntr-1.5.1/bin/cntr
 ```
 
+## Database Variants
+
+This project provides two database variants:
+
+- **Full (Default)**: Contains all indexed files (including headers, libraries, etc…). It is packaged as `nix-index-with-db`.
+- **Small**: Contains only files under `/bin/` directories (filtered database). It is much smaller, downloads faster, and consumes less memory. It is packaged as `nix-index-with-small-db` (and [comma](https://github.com/nix-community/nix-index-database/blob/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074/default.nix#L33-L35)).
+
+To switch to the small database, override the `nix-index` package in your configuration:
+
+```nix
+programs.nix-index.package = nix-index-database.packages.${pkgs.stdenv.hostPlatform.system}.nix-index-with-small-db;
+```
+
 ## Requirements
 
 - Nix 2.18 or newer: In our packages we make use of `unsafeDiscardReferences` to skip the nix store checks. On older nix version these packages might fail.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ cntr.out                                        978,736 x /nix/store/09p2hys5bxc
 
 This project provides two database variants:
 
-- **Full (Default)**: Contains all indexed files (including headers, libraries, etc…). It is packaged as `nix-index-with-db`.
-- **Small**: Contains only files under `/bin/` directories (filtered database). It is much smaller, downloads faster, and consumes less memory. It is packaged as `nix-index-with-small-db` (and [comma](https://github.com/nix-community/nix-index-database/blob/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074/default.nix#L33-L35)).
+- **Small (Default)**: Contains only files under `/bin/` directories (filtered database). It is much smaller, downloads faster, and consumes less memory. It is packaged as `nix-index-with-small-db` and is the default package, as well as the default for the NixOS, nix-darwin, and Home Manager modules (and [comma](https://github.com/nix-community/nix-index-database/blob/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074/default.nix#L33-L35)).
+- **Full**: Contains all indexed files (including headers, libraries, etc…). It is packaged as `nix-index-with-db`.
 
-To switch to the small database, override the `nix-index` package in your configuration:
+To switch to the full database, override the `nix-index` package in your configuration:
 
 ```nix
-programs.nix-index.package = nix-index-database.packages.${pkgs.stdenv.hostPlatform.system}.nix-index-with-small-db;
+programs.nix-index.package = nix-index-database.packages.${pkgs.stdenv.hostPlatform.system}.nix-index-with-db;
 ```
 
 ## Requirements

--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -10,7 +10,7 @@ in
 {
   imports = [ ./nix/shared.nix ];
 
-  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+  programs.nix-index.package = lib.mkDefault packages.nix-index-with-small-db;
   environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
     packages.comma-with-db
   ];

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         system:
         (mkPackages nixpkgs.legacyPackages.${system})
         // {
-          default = self.packages.${system}.nix-index-with-db;
+          default = self.packages.${system}.nix-index-with-small-db;
         }
       );
 

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -12,7 +12,7 @@ in
     ./nix/shared.nix
     ./nix/home-manager-options.nix
   ];
-  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+  programs.nix-index.package = lib.mkDefault packages.nix-index-with-small-db;
 
   home = {
     packages = lib.mkIf config.programs.nix-index-database.comma.enable [

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -19,7 +19,7 @@ in
 
   config = lib.mkIf config.programs.nix-index-database.enable {
     programs.nix-index.enable = lib.mkDefault true;
-    programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+    programs.nix-index.package = lib.mkDefault packages.nix-index-with-small-db;
     programs.command-not-found.enable = lib.mkDefault false;
     environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
       packages.comma-with-db


### PR DESCRIPTION
FIXES: #185

Makes the small/filtered database the default package for the NixOS, nix-darwin, and Home Manager modules, as well as the default flake package.