### PR TITLE
feat: Add package option to modules

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -10,8 +10,14 @@ in
 {
   imports = [ ./nix/shared.nix ];
 
-  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
-  environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
-    packages.comma-with-db
-  ];
+  options.programs.nix-index-database = {
+    package = lib.mkPackageOption packages "nix-index-with-db" { };
+  };
+
+  config = {
+    programs.nix-index.package = lib.mkDefault config.programs.nix-index-database.package;
+    environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
+      packages.comma-with-db
+    ];
+  };
 }

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -12,15 +12,21 @@ in
     ./nix/shared.nix
     ./nix/home-manager-options.nix
   ];
-  programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+  options.programs.nix-index-database = {
+    package = lib.mkPackageOption packages "nix-index-with-db" { };
+  };
 
-  home = {
-    packages = lib.mkIf config.programs.nix-index-database.comma.enable [
-      packages.comma-with-db
-    ];
+  config = {
+    programs.nix-index.package = lib.mkDefault config.programs.nix-index-database.package;
 
-    file."${config.xdg.cacheHome}/nix-index/files" =
-      lib.mkIf config.programs.nix-index.symlinkToCacheHome
-        { source = packages.nix-index-database; };
+    home = {
+      packages = lib.mkIf config.programs.nix-index-database.comma.enable [
+        packages.comma-with-db
+      ];
+
+      file."${config.xdg.cacheHome}/nix-index/files" =
+        lib.mkIf config.programs.nix-index.symlinkToCacheHome
+          { source = packages.nix-index-database; };
+    };
   };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -14,12 +14,13 @@ in
       description = "Whether to enable nix-index-database";
       type = lib.types.bool;
     };
+    package = lib.mkPackageOption packages "nix-index-with-db" { };
     comma.enable = lib.mkEnableOption "wrapping comma with nix-index-database and put it in the PATH";
   };
 
   config = lib.mkIf config.programs.nix-index-database.enable {
     programs.nix-index.enable = lib.mkDefault true;
-    programs.nix-index.package = lib.mkDefault packages.nix-index-with-db;
+    programs.nix-index.package = lib.mkDefault config.programs.nix-index-database.package;
     programs.command-not-found.enable = lib.mkDefault false;
     environment.systemPackages = lib.mkIf config.programs.nix-index-database.comma.enable [
       packages.comma-with-db


### PR DESCRIPTION
FIXES: #193

Introducing the `programs.nix-index-database.package` option to both the NixOS and Home Manager modules, using `lib.mkPackageOption`, so users can easily configure or override the index wrapper package