### PR TITLE
drop x86_64-darwin support

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -50,15 +50,13 @@ jobs:
     needs: create-release
     strategy:
       matrix:
-        system: ['x86_64-linux', 'aarch64-linux', 'x86_64-darwin', 'aarch64-darwin']
+        system: ['x86_64-linux', 'aarch64-linux', 'aarch64-darwin']
     name: Build database
     outputs:
       x86_64-linux-hash: ${{ steps.hashes.outputs.x86_64-linux }}
-      x86_64-darwin-hash: ${{ steps.hashes.outputs.x86_64-darwin }}
       aarch64-linux-hash: ${{ steps.hashes.outputs.aarch64-linux }}
       aarch64-darwin-hash: ${{ steps.hashes.outputs.aarch64-darwin }}
       x86_64-linux-small-hash: ${{ steps.hashes.outputs.x86_64-linux-small }}
-      x86_64-darwin-small-hash: ${{ steps.hashes.outputs.x86_64-darwin-small }}
       aarch64-linux-small-hash: ${{ steps.hashes.outputs.aarch64-linux-small }}
       aarch64-darwin-small-hash: ${{ steps.hashes.outputs.aarch64-darwin-small }}
     steps:
@@ -148,11 +146,9 @@ jobs:
           hashes = {
             x86_64-linux = "${{ needs.index.outputs.x86_64-linux-hash }}";
             aarch64-linux = "${{ needs.index.outputs.aarch64-linux-hash }}";
-            x86_64-darwin = "${{ needs.index.outputs.x86_64-darwin-hash }}";
             aarch64-darwin = "${{ needs.index.outputs.aarch64-darwin-hash }}";
             x86_64-linux-small = "${{ needs.index.outputs.x86_64-linux-small-hash }}";
             aarch64-linux-small = "${{ needs.index.outputs.aarch64-linux-small-hash }}";
-            x86_64-darwin-small = "${{ needs.index.outputs.x86_64-darwin-small-hash }}";
             aarch64-darwin-small = "${{ needs.index.outputs.aarch64-darwin-small-hash }}";
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
       ];
 
       systems = testSystems ++ [
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 

--- a/generated.nix
+++ b/generated.nix
@@ -4,11 +4,9 @@
   hashes = {
     x86_64-linux = "sha256-YlFxLeiDAwyqMAVQ3GPLMUd29QLOgZiIqrL0ruKYqyA=";
     aarch64-linux = "sha256-9PrJKZ2xaE49X6qgiQepfX4YeLNUwFiQeT466LWN4JU=";
-    x86_64-darwin = "sha256-wJs1yrhDS9HCgCYOAFL7ZlDkYnKr8ajuMdEmTWRFyBI=";
     aarch64-darwin = "sha256-iIt7VgR5GvWi8NnRUNGRhKtvKVCBZJeQeUKB90cC/3I=";
     x86_64-linux-small = "sha256-aBelT8BJX0evQ2+fon9K8FON36q/gr0b0VIW41u7qbQ=";
     aarch64-linux-small = "sha256-zwSbe2ucrcG33dYl/Gksc1UVoAL860gjj0bqS7YjDok=";
-    x86_64-darwin-small = "sha256-mk6jZGYmHI8U++TQpVV6KDYtkoqMH/Sq8VZYgunZ8so=";
     aarch64-darwin-small = "sha256-XsrTalwDGbym6jKy54DhepJmG3qqzF285AZw5oUe0Ps=";
   };
 }


### PR DESCRIPTION
GitHub CI can no longer build the x86_64-darwin index (the update workflow fails while generating it: https://github.com/nix-community/nix-index-database/actions/runs/29181590742/job/86620229944), and the platform is being phased out in nixpkgs.

Remove it from the flake systems, generated hashes and the index build matrix.